### PR TITLE
fixed nullpointer exception in addUser as discussed in forums

### DIFF
--- a/com/smartfoxserver/v2/entities/managers/SFSUserManager.hx
+++ b/com/smartfoxserver/v2/entities/managers/SFSUserManager.hx
@@ -84,7 +84,7 @@ class SFSUserManager implements IUserManager
 	public function addUser(user:User):Void
 	{
 		// TODO:very defensive, no need to fire exception, however we keep it for debugging
-		if(_usersById.exists(user.id))
+		if(_usersById.exists(user.id) && && _smartFox != null)
 			_smartFox.logger.warn("Unexpected:duplicate user in UserManager:" + user);
 			
 		_addUser(user);

--- a/com/smartfoxserver/v2/entities/managers/SFSUserManager.hx
+++ b/com/smartfoxserver/v2/entities/managers/SFSUserManager.hx
@@ -84,7 +84,7 @@ class SFSUserManager implements IUserManager
 	public function addUser(user:User):Void
 	{
 		// TODO:very defensive, no need to fire exception, however we keep it for debugging
-		if(_usersById.exists(user.id) && && _smartFox != null)
+		if(_usersById.exists(user.id) && _smartFox != null)
 			_smartFox.logger.warn("Unexpected:duplicate user in UserManager:" + user);
 			
 		_addUser(user);


### PR DESCRIPTION
There is a new fix for the Flash API in the AS3 client API 1.7.7 which we have received from the Smartfox team through email after discussing the problem here:
http://smartfoxserver.com/forums/viewtopic.php?f=18&t=20143&p=86848&hilit=adduser#p86848

In short, the client API was throwing an uncatchable error that broke the state of the client in rare cases. I have now replicated the fix in Haxe.

Edit: This is the fixed version, sorry for the earlier mistake.