### PR TITLE
turn safe cast to unsafe cast in getBool for iOS objective C target. …

### DIFF
--- a/com/smartfoxserver/v2/entities/data/SFSArray.hx
+++ b/com/smartfoxserver/v2/entities/data/SFSArray.hx
@@ -472,7 +472,7 @@ class SFSArray implements ISFSArray
 	public function getBool(index:Int):Null<Bool>
 	{
 		var wrapper:SFSDataWrapper = dataHolder[index];
-		return(wrapper != null ?cast(wrapper.data,Bool):null);
+		return(wrapper != null ?cast(wrapper.data):null);
 	}
 	
 	/** @inheritDoc */


### PR DESCRIPTION
…This fixes a problem where getBool would always return null on iOS