### PR TITLE
fixed users never removed from sfsglobalusermanager

### DIFF
--- a/com/smartfoxserver/v2/entities/managers/SFSGlobalUserManager.hx
+++ b/com/smartfoxserver/v2/entities/managers/SFSGlobalUserManager.hx
@@ -52,8 +52,8 @@ class SFSGlobalUserManager extends SFSUserManager
 				return;
 			}
 			
-			var n = _roomRefCount.get(user);
-			_roomRefCount.set(user,n--);
+			var newCount = _roomRefCount.get(user) - 1;
+			_roomRefCount.set(user, newCount);
 			
 			if(_roomRefCount.get(user)==0 || disconnected)
 			{


### PR DESCRIPTION
I noticed there was a memory leak where users were never removed from the SFSGlobalUserManager.hx after they were added, so it was growing indefinitely. The previous logic used this:

`_roomRefCount.set(user, n--);` which first sets the value, then decrements it. A fix would have been to use `_roomRefCount.set(user, --n);` which first decrements the value and then sets it. However I thought to avoid any confusion it's best to do the calculation in the previous expression and rename the variable accordingly.