### PR TITLE
fixed: user ref count never increased

### DIFF
--- a/com/smartfoxserver/v2/entities/managers/SFSGlobalUserManager.hx
+++ b/com/smartfoxserver/v2/entities/managers/SFSGlobalUserManager.hx
@@ -31,8 +31,8 @@ class SFSGlobalUserManager extends SFSUserManager
 		{
 			//trace("User duplicate FOUND. Incrementing value")
 			super._addUser(user);
-			var n = _roomRefCount.get(user);
-			_roomRefCount.set(user,n++);	
+			var newCount = _roomRefCount.get(user) + 1;
+			_roomRefCount.set(user,newCount);	
 		}			
 	}
 	


### PR DESCRIPTION
Same thing like the previous pull request, only this time when adding a user: The library was using `_roomRefCount.set(user,n++)` which first sets the value and then increments it. In practice that means the user count is always 1 and never increased and therefore the users are currently removed too early. This problem was not visible before because previously, users were never removed at all. With my last pull request however, they were now removed too early. This commit fixes the problem.