### PR TITLE
updated SFSUser externs for html5 api 1.7.x

### DIFF
--- a/com/smartfoxserver/v2/entities/SFSUser.hx
+++ b/com/smartfoxserver/v2/entities/SFSUser.hx
@@ -4,7 +4,7 @@ import com.smartfoxserver.v2.entities.variables.SFSUserVariable;
 import com.smartfoxserver.v2.entities.variables.UserVariable;
 
 #if html5
-@:native('SFS2X.Entities.SFSUser')
+@:native('Object')
 extern class SFSUser
 {
 	public var aoiEntryPoint:Dynamic;


### PR DESCRIPTION
In the current JavaScript client API, it is not possible to access the object SFSUser anymore, all instances of SFSUser are created internally by the SmartFoxServer 2X API. This PR allow us to deal with the type SFSUser at runtime