### PR TITLE
Fixing issue where roomListFromGroup returned a list with only the first room in the group.

### DIFF
--- a/com/smartfoxserver/v2/entities/managers/SFSRoomManager.hx
+++ b/com/smartfoxserver/v2/entities/managers/SFSRoomManager.hx
@@ -261,8 +261,7 @@ class SFSRoomManager implements IRoomManager
 		var roomList:Array<Room> = new Array();
 		for(room in _roomsById)
 		{
-			var room:Room =  _roomsById.iterator().next();
-			
+
 			if(room.groupId==groupId)
 				roomList.push(room);
 		}


### PR DESCRIPTION
there is no need for an iterator inside a loop already iterating the room list. the old code is just adding the first element to the array over and over again until the loop ended.