### PR TITLE
fix compilation for haxe 4.0.0-preview.5

### DIFF
--- a/com/smartfoxserver/v2/SmartFox.hx
+++ b/com/smartfoxserver/v2/SmartFox.hx
@@ -53,12 +53,12 @@ extern class SmartFox
 	public function removeEventListener(evtType:Dynamic, listener:Dynamic):Void;
 	public function send(request:Dynamic):Void;
 	public function setClientDetails(platformId:Int, version:String):Void;
-	public var roomList(get_roomList, null):Array<Room>;
+	public var roomList(get, null):Array<Room>;
  	inline function get_roomList():Array<Room>
 	{
 		return this.getRoomList();
 	}
-	public var connectionMode(get_connectionMode, null):String;
+	public var connectionMode(get, null):String;
 	inline function get_connectionMode():String
 	{
 		return ConnectionMode.SOCKET;
@@ -958,7 +958,7 @@ class SmartFox extends EventDispatcher
 	{
 		super();
 		
-		_log = new Logger();
+		_log = @:privateAccess new Logger();
 		_log.enableEventDispatching = true;
 		_debug = debug;
 		
@@ -1090,7 +1090,7 @@ class SmartFox extends EventDispatcher
 	 * 
 	 * Available under the kernel namespace
 	 */
-	public var socketEngine(get_socketEngine, null):BitSwarmClient;
+	public var socketEngine(get, null):BitSwarmClient;
  	private function get_socketEngine():BitSwarmClient
 	{
 		return _bitSwarm;
@@ -1103,7 +1103,7 @@ class SmartFox extends EventDispatcher
 	 * Available under the Kernel namespace
 	 */
 	@:allow(com.smartfoxserver.v2.controllers)
-	var lagMonitor(get_lagMonitor, null):LagMonitor;
+	var lagMonitor(get, null):LagMonitor;
  	private function get_lagMonitor():LagMonitor
 	{
 		return _lagMonitor;
@@ -1118,7 +1118,7 @@ class SmartFox extends EventDispatcher
 	 * trace("Am I connected?", sfs.isConnected);
 	 *</listing>
 	 */
-	public var isConnected(get_isConnected, null):Bool;
+	public var isConnected(get, null):Bool;
  	private function get_isConnected():Bool
 	{
 		var value:Bool = false;
@@ -1141,7 +1141,7 @@ class SmartFox extends EventDispatcher
 	 * 
 	 * @see	com.smartfoxserver.v2.util.ConnectionMode ConnectionMode
 	 */
-	public var connectionMode(get_connectionMode, null):String;
+	public var connectionMode(get, null):String;
  	private function get_connectionMode():String
 	{
 		return _bitSwarm.connectionMode;
@@ -1156,7 +1156,7 @@ class SmartFox extends EventDispatcher
 	 * trace("Current API version:", sfs.version);
 	 *</listing>
 	 */
-	public var version(get_version, null):String;
+	public var version(get, null):String;
  	private function get_version():String
 	{
 		return "" + _majVersion + "." + _minVersion + "." + _subVersion;
@@ -1195,7 +1195,7 @@ class SmartFox extends EventDispatcher
 	 * }
 	 *</listing>
 	 */
-	public var httpUploadURI(get_httpUploadURI, null):String;
+	public var httpUploadURI(get, null):String;
  	private function get_httpUploadURI():String
 	{
 		if(config==null || mySelf==null)
@@ -1211,7 +1211,7 @@ class SmartFox extends EventDispatcher
 	 * @see		#loadConfig()
 	 * @see		#connectWithConfig()
 	 */
-	public var config(get_config, null):ConfigData;
+	public var config(get, null):ConfigData;
  	private function get_config():ConfigData
 	{
 		return _config;
@@ -1222,7 +1222,7 @@ class SmartFox extends EventDispatcher
 	 *<p>This value represents the maximum message size(in bytes)before the protocol compression is activated. 
 	 * It is determined by the server configuration.</p>
 	 */
-	public var compressionThreshold(get_compressionThreshold, null):Int;
+	public var compressionThreshold(get, null):Int;
  	private function get_compressionThreshold():Int
 	{
 		return _bitSwarm.compressionThreshold;
@@ -1233,7 +1233,7 @@ class SmartFox extends EventDispatcher
 	 *<p>Any request exceeding this size will not be sent.
 	 * The value is determined by the server configuration.</p>
 	 */
-	public var maxMessageSize(get_maxMessageSize, null):Int;
+	public var maxMessageSize(get, null):Int;
  	private function get_maxMessageSize():Int
 	{
 		return _bitSwarm.maxMessageSize;
@@ -1442,7 +1442,7 @@ class SmartFox extends EventDispatcher
 	 * If set to<code>true</code>, detailed debugging informations for all the incoming and outgoing messages are provided.
 	 *<p>Debugging can be enabled when instantiating the<em>SmartFox</em>class too.</p>
 	 */
-	public var debug(get_debug, set_debug):Bool;
+	public var debug(get, set):Bool;
  	private function get_debug():Bool
 	{
 		return _debug;
@@ -1461,7 +1461,7 @@ class SmartFox extends EventDispatcher
 	 * @see		#connect()
 	 * @see		#loadConfig()
 	 */
-	public var currentIp(get_currentIp, null):String;
+	public var currentIp(get, null):String;
  	private function get_currentIp():String
 	{
 		return _bitSwarm.connectionIp;
@@ -1474,7 +1474,7 @@ class SmartFox extends EventDispatcher
 	 * @see		#connect()
 	 * @see		#loadConfig()
 	 */
-	public var currentPort(get_currentPort, null):Int;
+	public var currentPort(get, null):Int;
  	private function get_currentPort():Int
 	{
 		return _bitSwarm.connectionPort;
@@ -1486,7 +1486,7 @@ class SmartFox extends EventDispatcher
 	 * @see		#loadConfig()
 	 * @see		com.smartfoxserver.v2.requests.LoginRequest LoginRequest
 	 */
-	public var currentZone(get_currentZone, null):String;
+	public var currentZone(get, null):String;
  	private function get_currentZone():String
 	{
 		return _currentZone;
@@ -1501,7 +1501,7 @@ class SmartFox extends EventDispatcher
 	 * @see		com.smartfoxserver.v2.entities.User#isItMe User.isItMe
 	 * @see		com.smartfoxserver.v2.requests.LoginRequest LoginRequest
 	 */
-	public var mySelf(get_mySelf, set_mySelf):User;
+	public var mySelf(get, set):User;
  	private function get_mySelf():User
 	{
 		return _mySelf;
@@ -1522,7 +1522,7 @@ class SmartFox extends EventDispatcher
 	 * @see #connectionMode connectionMode
 	 * @see #loadConfig()
 	 */ 
-	public var useBlueBox(get_useBlueBox, set_useBlueBox):Bool;
+	public var useBlueBox(get, set):Bool;
  	private function get_useBlueBox():Bool
 	{
 		return _useBlueBox;
@@ -1537,7 +1537,7 @@ class SmartFox extends EventDispatcher
 	/**
 	 * Returns a reference to the Internal<em>Logger</em>instance used by SmartFoxServer 2X.
 	 */
-	public var logger(get_logger, null):Logger;
+	public var logger(get, null):Logger;
  	private function get_logger():Logger
 	{
 		return _log;
@@ -1553,7 +1553,7 @@ class SmartFox extends EventDispatcher
 	 * @see		#joinedRooms()
 	 * @see		com.smartfoxserver.v2.requests.JoinRoomRequest JoinRoomRequest
 	 */
-	public var lastJoinedRoom(get_lastJoinedRoom, set_lastJoinedRoom):Room;
+	public var lastJoinedRoom(get, set):Room;
  	private function get_lastJoinedRoom():Room
 	{
 		return _lastJoinedRoom;
@@ -1576,7 +1576,7 @@ class SmartFox extends EventDispatcher
 	 * @see		com.smartfoxserver.v2.entities.Room Room
 	 * @see		com.smartfoxserver.v2.requests.JoinRoomRequest JoinRoomRequest
 	 */
-	public var joinedRooms(get_joinedRooms, null):Array<Room>;
+	public var joinedRooms(get, null):Array<Room>;
  	private function get_joinedRooms():Array<Room>
 	{
 		return roomManager.getJoinedRooms();
@@ -1596,7 +1596,7 @@ class SmartFox extends EventDispatcher
 	 * @see 	com.smartfoxserver.v2.requests.SubscribeRoomGroupRequest SubscribeRoomGroupRequest
 	 * @see 	com.smartfoxserver.v2.requests.UnsubscribeRoomGroupRequest UnsubscribeRoomGroupRequest
 	 */
-	public var roomList(get_roomList, null):Array<Room>;
+	public var roomList(get, null):Array<Room>;
  	private function get_roomList():Array<Room>
 	{
 		return _roomManager.getRoomList();
@@ -1607,7 +1607,7 @@ class SmartFox extends EventDispatcher
 	 * This manager is used Internally by the SmartFoxServer 2X API;the reference returned by this property
 	 * gives access to the Rooms list and Groups, allowing Interaction with<em>Room</em>objects.
 	 */
-	public var roomManager(get_roomManager, null):IRoomManager;
+	public var roomManager(get, null):IRoomManager;
  	private function get_roomManager():IRoomManager
 	{
 		return _roomManager;
@@ -1618,7 +1618,7 @@ class SmartFox extends EventDispatcher
 	 * This manager is used Internally by the SmartFoxServer 2X API;the reference returned by this property
 	 * gives access to the users list, allowing Interaction with<em>User</em>objects.
 	 */
-	public var userManager(get_userManager, set_userManager):IUserManager;
+	public var userManager(get, set):IUserManager;
  	private function get_userManager():IUserManager
 	{
 		return _userManager;
@@ -1634,7 +1634,7 @@ class SmartFox extends EventDispatcher
 	 * This manager is used Internally by the SmartFoxServer 2X API;the reference returned by this property
 	 * gives access to the buddies list, allowing Interaction with<em>Buddy</em>and<em>BuddyVariable</em>objects and access to user properties in the<b>Buddy List</b>system.
 	 */
-	public var buddyManager(get_buddyManager, set_buddyManager):IBuddyManager;
+	public var buddyManager(get, set):IBuddyManager;
  	private function get_buddyManager():IBuddyManager
 	{
 		return _buddyManager;
@@ -1654,7 +1654,7 @@ class SmartFox extends EventDispatcher
 	 * 
 	 * @see		#initUDP()
 	 */
-	public var udpAvailable(get_udpAvailable, null):Bool;
+	public var udpAvailable(get, null):Bool;
  	private function get_udpAvailable():Bool
 	{
 		return isAirRuntime();
@@ -1666,7 +1666,7 @@ class SmartFox extends EventDispatcher
 	 * @see		#udpAvailable
 	 * @see		#initUDP()
 	 */
-	public var udpInited(get_udpInited, null):Bool;
+	public var udpInited(get, null):Bool;
  	private function get_udpInited():Bool
 	{
 		return _bitSwarm.udpManager.inited;
@@ -1825,7 +1825,7 @@ class SmartFox extends EventDispatcher
 	}
 	
 	/** @private */
-	public var isJoining(get_isJoining, set_isJoining):Bool;
+	public var isJoining(get, set):Bool;
  	private function get_isJoining():Bool
 	{
 		return _isJoining;
@@ -1844,7 +1844,7 @@ class SmartFox extends EventDispatcher
 	 * 
 	 * @see		#httpUploadURI
 	 */
-	public var sessionToken(get_sessionToken, null):String;
+	public var sessionToken(get, null):String;
  	private function get_sessionToken():String
 	{
 		return _sessionToken;

--- a/com/smartfoxserver/v2/bitswarm/AirUDPManager.hx
+++ b/com/smartfoxserver/v2/bitswarm/AirUDPManager.hx
@@ -153,7 +153,7 @@ class AirUDPManager implements IUDPManager
 	/**
 	 * @private
 	 */
-	public var inited(get_inited, set_inited):Bool;
+	public var inited(get, set):Bool;
  	private function get_inited():Bool
 	{
 		return _initSuccess;			
@@ -162,7 +162,7 @@ class AirUDPManager implements IUDPManager
 	/**
 	 * @private
 	 */
-	public var sfs(null, set_sfs):SmartFox;
+	public var sfs(null, set):SmartFox;
  	private function set_sfs(sfs:SmartFox):Void
 	{
 		this._sfs = sfs;

--- a/com/smartfoxserver/v2/bitswarm/BaseController.hx
+++ b/com/smartfoxserver/v2/bitswarm/BaseController.hx
@@ -14,7 +14,7 @@ class BaseController implements IController
 		log = bitSwarm.sfs.logger;
 	}
 	
-	public var id(get_id, set_id):Int;
+	public var id(get, set):Int;
  	private function get_id():Int
 	{
 		return _id;

--- a/com/smartfoxserver/v2/bitswarm/BitSwarmClient.hx
+++ b/com/smartfoxserver/v2/bitswarm/BitSwarmClient.hx
@@ -73,7 +73,7 @@ class BitSwarmClient extends EventDispatcher
 		return _connectionMode;
 	}
 	
-	public var ioHandler(get_ioHandler, set_ioHandler):IoHandler;
+	public var ioHandler(get, set):IoHandler;
  	private function get_ioHandler():IoHandler
 	{
 		return _ioHandler;
@@ -87,7 +87,7 @@ class BitSwarmClient extends EventDispatcher
 		return _ioHandler = value;
 	}
 	
-	public var maxMessageSize(get_maxMessageSize, set_maxMessageSize):Int;
+	public var maxMessageSize(get, set):Int;
  	private function get_maxMessageSize():Int
 	{
 		return _maxMessageSize;
@@ -98,7 +98,7 @@ class BitSwarmClient extends EventDispatcher
 		return _maxMessageSize = value;
 	}
 	
-	public var compressionThreshold(get_compressionThreshold, set_compressionThreshold):Int;
+	public var compressionThreshold(get, set):Int;
  	private function get_compressionThreshold():Int
 	{
 		return _compressionThreshold;
@@ -116,13 +116,13 @@ class BitSwarmClient extends EventDispatcher
 			throw new ArgumentError("Compression threshold cannot be<100 bytes.");
 	}
 	
-	public var reconnectionDelayMillis(get_reconnectionDelayMillis, set_reconnectionDelayMillis):Int;
+	public var reconnectionDelayMillis(get, set):Int;
  	private function get_reconnectionDelayMillis():Int
 	{
 		return _reconnectionDelayMillis;
 	}
 	
-	public var useBlueBox(get_useBlueBox, null):Bool;
+	public var useBlueBox(get, null):Bool;
  	private function get_useBlueBox():Bool
 	{
 		return _useBlueBox;	
@@ -193,19 +193,19 @@ class BitSwarmClient extends EventDispatcher
 		return _controllers.get(id);
 	}
 	
-	public var systemController(get_systemController, null):SystemController;
+	public var systemController(get, null):SystemController;
  	private function get_systemController():SystemController
 	{
 		return _sysController;
 	}
 	
-	public var extensionController(get_extensionController, null):ExtensionController;
+	public var extensionController(get, null):ExtensionController;
  	private function get_extensionController():ExtensionController
 	{
 		return _extController;
 	}
 	
-	public var isReconnecting(get_isReconnecting, set_isReconnecting):Bool;
+	public var isReconnecting(get, set):Bool;
  	private function get_isReconnecting():Bool
 	{
 		return _attemptingReconnection;
@@ -221,7 +221,7 @@ class BitSwarmClient extends EventDispatcher
 		return _controllers.get(id);
 	}
 	
-	public var connectionIp(get_connectionIp, null):String;
+	public var connectionIp(get, null):String;
  	private function get_connectionIp():String
 	{
 		if(!connected)
@@ -328,7 +328,7 @@ class BitSwarmClient extends EventDispatcher
 		executeDisconnection(null);
 	}
 	
-	public var udpManager(get_udpManager, set_udpManager):IUDPManager;
+	public var udpManager(get, set):IUDPManager;
  	private function get_udpManager():IUDPManager
 	{
 		return _udpManager;
@@ -351,7 +351,7 @@ class BitSwarmClient extends EventDispatcher
 		addController(1, _extController);
 	}
 	
-	public var reconnectionSeconds(get_reconnectionSeconds, set_reconnectionSeconds):Int;
+	public var reconnectionSeconds(get, set):Int;
  	private function get_reconnectionSeconds():Int
 	{
 		return _reconnectionSeconds;

--- a/com/smartfoxserver/v2/bitswarm/IController.hx
+++ b/com/smartfoxserver/v2/bitswarm/IController.hx
@@ -3,7 +3,7 @@ package com.smartfoxserver.v2.bitswarm;
 /** @private */
 interface IController
 {
-	public var id(get_id, set_id):Int;
+	public var id(get, set):Int;
 	
 	function handleMessage(message:IMessage):Void;
 }

--- a/com/smartfoxserver/v2/bitswarm/IoHandler.hx
+++ b/com/smartfoxserver/v2/bitswarm/IoHandler.hx
@@ -9,5 +9,5 @@ interface IoHandler
 {
 	function onDataRead(buffer:ByteArray):Void;
 	function onDataWrite(message:IMessage):Void;
-	var codec(get_codec, set_codec):IProtocolCodec;
+	var codec(get, set):IProtocolCodec;
 }

--- a/com/smartfoxserver/v2/bitswarm/PendingPacket.hx
+++ b/com/smartfoxserver/v2/bitswarm/PendingPacket.hx
@@ -21,7 +21,7 @@ class PendingPacket
 	public var header(get, set):PacketHeader;
 	
 	
-	public var buffer(get_buffer, set_buffer):ByteArray;
+	public var buffer(get, set):ByteArray;
  	private function get_buffer():ByteArray
 	{
 		return _buffer;

--- a/com/smartfoxserver/v2/bitswarm/bbox/BBClient.hx
+++ b/com/smartfoxserver/v2/bitswarm/bbox/BBClient.hx
@@ -61,19 +61,19 @@ class BBClient extends EventDispatcher
 	// Getters / Setters
 	//::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 	
-	public var isConnected(get_isConnected, null):Bool;
+	public var isConnected(get, null):Bool;
  	private function get_isConnected():Bool
 	{
 		return _sessId !=null;		
 	}
 	
-	public var isDebug(get_isDebug, set_isDebug):Bool;
+	public var isDebug(get, set):Bool;
  	private function get_isDebug():Bool
 	{
 		return _debug;		
 	}
 	
-	public var host(get_host, set_host):String;
+	public var host(get, set):String;
  	private function get_host():String
 	{
 		return _host;		
@@ -82,7 +82,7 @@ class BBClient extends EventDispatcher
 	{
 		return _host = value;		
 	}
-	public var port(get_port, set_port):Int;
+	public var port(get, set):Int;
  	private function get_port():Int
 	{
 		return _port;		
@@ -91,7 +91,7 @@ class BBClient extends EventDispatcher
 	{
 		return _port = value;		
 	}
-	public var sessionId(get_sessionId, set_sessionId):String;
+	public var sessionId(get, set):String;
  	private function get_sessionId():String
 	{
 		return _sessId;		

--- a/com/smartfoxserver/v2/core/PacketHeader.hx
+++ b/com/smartfoxserver/v2/core/PacketHeader.hx
@@ -35,7 +35,7 @@ class PacketHeader
 							);
 	}
 	
-	public var expectedLen(get_expectedLen, set_expectedLen):Int;
+	public var expectedLen(get, set):Int;
  	private function get_expectedLen():Int
 	{
 		return _expectedLen;
@@ -45,7 +45,7 @@ class PacketHeader
 		return _expectedLen = value;
 	}
 	
-	public var binary(get_binary, set_binary):Bool;
+	public var binary(get, set):Bool;
  	private function get_binary():Bool
 	{
 		return _binary;
@@ -55,7 +55,7 @@ class PacketHeader
 		return _binary = value;
 	}
 	
-	public var compressed(get_compressed, set_compressed):Bool;
+	public var compressed(get, set):Bool;
  	private function get_compressed():Bool
 	{
 		return _compressed;
@@ -65,7 +65,7 @@ class PacketHeader
 		return _compressed = value;
 	}
 	
-	public var encrypted(get_encrypted, set_encrypted):Bool;
+	public var encrypted(get, set):Bool;
  	private function get_encrypted():Bool
 	{
 		return	_encrypted;
@@ -75,7 +75,7 @@ class PacketHeader
 		return _encrypted = value;
 	}
 	
-	public var blueBoxed(get_blueBoxed, set_blueBoxed):Bool;
+	public var blueBoxed(get, set):Bool;
  	private function get_blueBoxed():Bool
 	{
 		return	_blueBoxed;	
@@ -86,7 +86,7 @@ class PacketHeader
 		return _blueBoxed = value;	
 	}
 	
-	public var bigSized(get_bigSized, set_bigSized):Bool;
+	public var bigSized(get, set):Bool;
  	private function get_bigSized():Bool
 	{
 		return	_bigSized;

--- a/com/smartfoxserver/v2/core/SFSIOHandler.hx
+++ b/com/smartfoxserver/v2/core/SFSIOHandler.hx
@@ -49,7 +49,7 @@ class SFSIOHandler implements IoHandler
 		fullPacketDump=b;
 	}
 	
-	public var codec(get_codec, set_codec):IProtocolCodec;
+	public var codec(get, set):IProtocolCodec;
  	private function get_codec():IProtocolCodec
 	{
 		return protocolCodec;

--- a/com/smartfoxserver/v2/core/SFSProtocolCodec.hx
+++ b/com/smartfoxserver/v2/core/SFSProtocolCodec.hx
@@ -108,7 +108,7 @@ class SFSProtocolCodec implements IProtocolCodec
 		return sfsObj;
 	}
 	
-	public var ioHandler(get_ioHandler, set_ioHandler):IoHandler;
+	public var ioHandler(get, set):IoHandler;
  	private function get_ioHandler():IoHandler
 	{
 		return _ioHandler;

--- a/com/smartfoxserver/v2/entities/Buddy.hx
+++ b/com/smartfoxserver/v2/entities/Buddy.hx
@@ -19,7 +19,7 @@ interface Buddy
 	 * 
 	 * @see		User#id
 	 */
-	public var id(get_id, null):Int;
+	public var id(get, null):Int;
 	
 	/**
 	 * Indicates the name of this buddy.
@@ -27,7 +27,7 @@ interface Buddy
 	 * 
 	 * @see		User#name
 	 */
-	var  name(get_name,null):String;
+	var  name(get,null):String;
 	
 	/**
 	 * Indicates whether this buddy is blocked in the current user's buddies list or not.
@@ -40,12 +40,12 @@ interface Buddy
 	/**
 	 * Indicates whether this buddy is online in the Buddy List system or not.
 	 */
-	var isOnline(get_isOnline,null):Bool;
+	var isOnline(get,null):Bool;
 	
 	/**
 	 * Indicates whether this buddy is temporary(non-persistent)in the current user's buddies list or not.
 	 */
-	var isTemp(get_isTemp,null):Bool;
+	var isTemp(get,null):Bool;
 	
 	/**
 	 * Returns the custom state of this buddy.
@@ -55,13 +55,13 @@ interface Buddy
 	 * 
 	 * @see		com.smartfoxserver.v2.entities.managers.IBuddyManager#buddyStates IBuddyManager.buddyStates
 	 */
-	var state(get_state,null):String;
+	var state(get,null):String;
 	
 	/**
 	 * Returns the nickname of this buddy.
 	 * If the nickname is not set,<code>null</code>is returned.
 	 */
-	var nickName(get_nickName,null):String;
+	var nickName(get,null):String;
 	
 	/**
 	 * Returns a list of<em>BuddyVariable</em>objects associated with the buddy.
@@ -69,7 +69,7 @@ interface Buddy
 	 * @see		com.smartfoxserver.v2.entities.variables.BuddyVariable BuddyVariable
 	 * @see		#getVariable()
 	 */ 
-	var variables(get_variables,null):Array<BuddyVariable>;
+	var variables(get,null):Array<BuddyVariable>;
 	
 	/**
 	 * Retrieves a Buddy Variable from its name.

--- a/com/smartfoxserver/v2/entities/IMMOItem.hx
+++ b/com/smartfoxserver/v2/entities/IMMOItem.hx
@@ -64,6 +64,6 @@ interface IMMOItem
 	 * @see com.smartfoxserver.v2.requests.mmo.MMORoomSettings#sendAOIEntryPoint sendAOIEntryPoint
 	 * @see	com.smartfoxserver.v2.SmartFox#event:proximityListUpdate proximityListUpdate event 
 	 */
-	public var aoiEntryPoint(get_aoiEntryPoint, set_aoiEntryPoint):Vec3D;
+	public var aoiEntryPoint(get, set):Vec3D;
 }
 #end

--- a/com/smartfoxserver/v2/entities/MMOItem.hx
+++ b/com/smartfoxserver/v2/entities/MMOItem.hx
@@ -67,7 +67,7 @@ class MMOItem implements IMMOItem
 	}
 	
 	/** @inheritDoc */
-	public var id(get_id, set_id):Int;
+	public var id(get, set):Int;
  	private function get_id():Int
 	{
 		return _id;
@@ -124,7 +124,7 @@ class MMOItem implements IMMOItem
 	}
 	
 	/** @inheritDoc */
-	public var aoiEntryPoint(get_aoiEntryPoint, set_aoiEntryPoint):Vec3D;
+	public var aoiEntryPoint(get, set):Vec3D;
  	private function get_aoiEntryPoint():Vec3D
 	{
 		return _aoiEntryPoint;

--- a/com/smartfoxserver/v2/entities/MMORoom.hx
+++ b/com/smartfoxserver/v2/entities/MMORoom.hx
@@ -61,7 +61,7 @@ class MMORoom extends SFSRoom
 	 * 
 	 * @see	com.smartfoxserver.v2.requests.mmo.MMORoomSettings#defaultAOI MMORoomSettings.defaultAOI
 	 */
-	public var defaultAOI(get_defaultAOI, set_defaultAOI):Vec3D;
+	public var defaultAOI(get, set):Vec3D;
  	private function get_defaultAOI():Vec3D
 	{
 		return _defaultAOI;
@@ -73,7 +73,7 @@ class MMORoom extends SFSRoom
 	 * 
 	 * @see	com.smartfoxserver.v2.requests.mmo.MMORoomSettings#mapLimits MMORoomSettings.mapLimits
 	 */
-	public var lowerMapLimit(get_lowerMapLimit, set_lowerMapLimit):Vec3D;
+	public var lowerMapLimit(get, set):Vec3D;
  	private function get_lowerMapLimit():Vec3D
 	{
 		return _lowerMapLimit;	
@@ -85,7 +85,7 @@ class MMORoom extends SFSRoom
 	 * 
 	 * @see	com.smartfoxserver.v2.requests.mmo.MMORoomSettings#mapLimits MMORoomSettings.mapLimits
 	 */
-	public var higherMapLimit(get_higherMapLimit, set_higherMapLimit):Vec3D;
+	public var higherMapLimit(get, set):Vec3D;
  	private function get_higherMapLimit():Vec3D
 	{
 		return _higherMapLimit;

--- a/com/smartfoxserver/v2/entities/SFSBuddy.hx
+++ b/com/smartfoxserver/v2/entities/SFSBuddy.hx
@@ -104,35 +104,35 @@ class SFSBuddy implements Buddy
 	}
 	
 	/** @inheritDoc */
-	public var id(get_id, null):Int;
+	public var id(get, null):Int;
  	private function get_id():Int
 	{
 		return _id;
 	}
 	
 	/** @inheritDoc */
-	public var name(get_name, null):String;
+	public var name(get, null):String;
  	private function get_name():String
 	{
 		return _name;
 	}
 	
 	/** @inheritDoc */
-	public var isBlocked(get_isBlocked, null):Bool;
+	public var isBlocked(get, null):Bool;
  	private function get_isBlocked():Bool
 	{
 		return _isBlocked;
 	}
 	
 	/** @inheritDoc */
-	public var isTemp(get_isTemp, null):Bool;
+	public var isTemp(get, null):Bool;
  	private function get_isTemp():Bool
 	{
 		return _isTemp;
 	}
 	
 	/** @inheritDoc */
-	public var isOnline(get_isOnline, null):Bool;
+	public var isOnline(get, null):Bool;
  	private function get_isOnline():Bool
 	{
 		var bv:BuddyVariable = getVariable(ReservedBuddyVariables.BV_ONLINE);
@@ -148,7 +148,7 @@ class SFSBuddy implements Buddy
 	}
 	
 	/** @inheritDoc */
-	public var state(get_state, null):String;
+	public var state(get, null):String;
  	private function get_state():String
 	{
 		/*
@@ -160,7 +160,7 @@ class SFSBuddy implements Buddy
 	}
 
 	/** @inheritDoc */		
-	public var nickName(get_nickName, null):String;
+	public var nickName(get, null):String;
  	private function get_nickName():String
 	{
 		var bv:BuddyVariable = getVariable(ReservedBuddyVariables.BV_NICKNAME);
@@ -168,7 +168,7 @@ class SFSBuddy implements Buddy
 	}
 	
 	/** @inheritDoc */
-	public var variables(get_variables, null):Array<BuddyVariable>;
+	public var variables(get, null):Array<BuddyVariable>;
  	private function get_variables():Array<BuddyVariable>
 	{
 		return Lambda.array(_variables);

--- a/com/smartfoxserver/v2/entities/SFSRoom.hx
+++ b/com/smartfoxserver/v2/entities/SFSRoom.hx
@@ -32,7 +32,7 @@ extern class SFSRoom{
 	function getVariable(varName:String):RoomVariable;
 	function getVariables():Array<RoomVariable>;
 	function toString():String;
-	public var roomManager(get_roomManager, set_roomManager):IRoomManager;
+	public var roomManager(get, set):IRoomManager;
  	inline private function get_roomManager():IRoomManager
 	{
 		return getRoomManager();
@@ -201,14 +201,14 @@ class SFSRoom implements Room
 	}
 	
 	/** @inheritDoc */
-	public var id(get_id, null):Int;
+	public var id(get, null):Int;
  	private function get_id():Int
 	{
 		return _id;
 	}
 	
 	/** @inheritDoc */
-	public var name(get_name, set_name):String;
+	public var name(get, set):String;
  	private function get_name():String	
 	{
 		return _name;
@@ -221,28 +221,28 @@ class SFSRoom implements Room
 	}
 	
 	/** @inheritDoc */
-	public var groupId(get_groupId, null):String;
+	public var groupId(get, null):String;
  	private function get_groupId():String
 	{
 		return _groupId;
 	}
 	
 	/** @inheritDoc */
-	public var isGame(get_isGame, set_isGame):Bool;
+	public var isGame(get, set):Bool;
  	private function get_isGame():Bool
 	{
 		return _isGame;		
 	}
 	
 	/** @inheritDoc */
-	public var isHidden(get_isHidden, set_isHidden):Bool;
+	public var isHidden(get, set):Bool;
  	private function get_isHidden():Bool
 	{
 		return _isHidden;
 	}
 	
 	/** @inheritDoc */
-	public var isJoined(get_isJoined, set_isJoined):Bool;
+	public var isJoined(get, set):Bool;
  	private function get_isJoined():Bool
 	{
 		return _isJoined;
@@ -280,7 +280,7 @@ class SFSRoom implements Room
 	}
 	
 	/** @private */
-	public var isManaged(get_isManaged, set_isManaged):Bool;
+	public var isManaged(get, set):Bool;
  	private function get_isManaged():Bool
 	{
 		return _isManaged;
@@ -311,7 +311,7 @@ class SFSRoom implements Room
 	*/
 	
 	/** @inheritDoc */
-	public var userCount(get_userCount, set_userCount):Int;
+	public var userCount(get, set):Int;
  	private function get_userCount():Int
 	{
 		// Return server count from UCountUpdate	
@@ -332,21 +332,21 @@ class SFSRoom implements Room
 	}
 	
 	/** @inheritDoc */
-	public var maxUsers(get_maxUsers, set_maxUsers):Int;
+	public var maxUsers(get, set):Int;
  	private function get_maxUsers():Int
 	{
 		return _maxUsers;
 	}
 	
 	/** @inheritDoc */
-	public var capacity(get_capacity, null):Int;
+	public var capacity(get, null):Int;
  	private function get_capacity():Int
 	{
 		return _maxUsers + _maxSpectators;
 	}
 	
 	/** @inheritDoc */
-	public var spectatorCount(get_spectatorCount, set_spectatorCount):Int;
+	public var spectatorCount(get, set):Int;
  	private function get_spectatorCount():Int
 	{
 		// No spectators in regular rooms
@@ -363,7 +363,7 @@ class SFSRoom implements Room
 	}
 	
 	/** @inheritDoc */
-	public var maxSpectators(get_maxSpectators, set_maxSpectators):Int;
+	public var maxSpectators(get, set):Int;
  	private function get_maxSpectators():Int
 	{
 		return _maxSpectators;
@@ -406,14 +406,14 @@ class SFSRoom implements Room
 	}
 	
 	/** @inheritDoc */
-	public var userList(get_userList, null):Array<User>;
+	public var userList(get, null):Array<User>;
  	private function get_userList():Array<User>
 	{
 		return _userManager.getUserList();
 	}
 	
 	/** @inheritDoc */
-	public var playerList(get_playerList, null):Array<User>;
+	public var playerList(get, null):Array<User>;
  	private function get_playerList():Array<User>
 	{
 		var playerList:Array<User> = [];
@@ -428,7 +428,7 @@ class SFSRoom implements Room
 	}
 	
 	/** @inheritDoc */
-	public var spectatorList(get_spectatorList, null):Array<User>;
+	public var spectatorList(get, null):Array<User>;
  	private function get_spectatorList():Array<User>
 	{
 		var spectatorList:Array<User> = [];
@@ -475,7 +475,7 @@ class SFSRoom implements Room
 	}
 	
 	/** @inheritDoc */
-	public var properties(get_properties, set_properties):Dynamic;
+	public var properties(get, set):Dynamic;
  	private function get_properties():Dynamic
 	{
 		return _properties;
@@ -500,7 +500,7 @@ class SFSRoom implements Room
 	}
 	
 	/** @inheritDoc */
-	public var roomManager(get_roomManager, set_roomManager):IRoomManager;
+	public var roomManager(get, set):IRoomManager;
  	private function get_roomManager():IRoomManager
 	{
 		return _roomManager;

--- a/com/smartfoxserver/v2/entities/SFSUser.hx
+++ b/com/smartfoxserver/v2/entities/SFSUser.hx
@@ -125,21 +125,21 @@ class SFSUser implements User
 	}
 	
 	/** @inheritDoc */
-	public var id(get_id, null):Int;
+	public var id(get, null):Int;
  	private function get_id():Int
 	{
 		return _id;
 	}
 	
 	/** @inheritDoc */
-	public var name(get_name, null):String;
+	public var name(get, null):String;
  	private function get_name():String
 	{
 		return _name;
 	}
 	
 	/** @inheritDoc */
-	public var playerId(get_playerId, null):Null<Int>;
+	public var playerId(get, null):Null<Int>;
  	private function get_playerId():Null<Int>
 	{
 		// Return from default room
@@ -154,7 +154,7 @@ class SFSUser implements User
 	
 	
 	/** @inheritDoc */
-	public var privilegeId(get_privilegeId, set_privilegeId):Int;
+	public var privilegeId(get, set):Int;
  	private function get_privilegeId():Int
 	{
 		return _privilegeId;
@@ -191,14 +191,14 @@ class SFSUser implements User
 	}
 	
 	/** @inheritDoc */
-	public var isPlayer(get_isPlayer, null):Bool;
+	public var isPlayer(get, null):Bool;
  	private function get_isPlayer():Bool
 	{
 		return playerId > 0;
 	}
 	
 	/** @inheritDoc */
-	public var isSpectator(get_isSpectator, null):Bool;
+	public var isSpectator(get, null):Bool;
  	private function get_isSpectator():Bool
 	{
 		return !this.isPlayer;
@@ -240,14 +240,14 @@ class SFSUser implements User
 	}
 	
 	/** @inheritDoc */
-	public var isItMe(get_isItMe, null):Bool;
+	public var isItMe(get, null):Bool;
  	private function get_isItMe():Bool
 	{
 		return _isItMe;
 	}
 	
 	/** @inheritDoc */
-	public var userManager(get_userManager, set_userManager):IUserManager;
+	public var userManager(get, set):IUserManager;
  	private function get_userManager():IUserManager
 	{
 		return _userManager;
@@ -314,7 +314,7 @@ class SFSUser implements User
 	}
 	
 	/** @inheritDoc */
-	public var properties(get_properties, set_properties):Dynamic;
+	public var properties(get, set):Dynamic;
  	private function get_properties():Dynamic
 	{
 		return _properties;
@@ -327,7 +327,7 @@ class SFSUser implements User
 	}
 	
 	/** @inheritDoc */
-	public var aoiEntryPoint(get_aoiEntryPoint, set_aoiEntryPoint):Vec3D;
+	public var aoiEntryPoint(get, set):Vec3D;
  	private function get_aoiEntryPoint():Vec3D
 	{
 		return _aoiEntryPoint;

--- a/com/smartfoxserver/v2/entities/data/Vec3D.hx
+++ b/com/smartfoxserver/v2/entities/data/Vec3D.hx
@@ -59,7 +59,7 @@ class Vec3D
 	/**
 	 * Returns the position along the X axis.
 	 */
-	public var px(get_px, null):Float;
+	public var px(get, null):Float;
  	private function get_px():Float
 	{
 		return _px;
@@ -68,7 +68,7 @@ class Vec3D
 	/**
 	 * Returns the position along the Y axis.
 	 */
-	public var py(get_py, null):Float;
+	public var py(get, null):Float;
  	private function get_py():Float
 	{
 		return _py;
@@ -77,7 +77,7 @@ class Vec3D
 	/**
 	 * Returns the position along the Z axis.
 	 */
-	public var pz(get_pz, null):Float;
+	public var pz(get, null):Float;
  	private function get_pz():Float
 	{
 		return _pz;

--- a/com/smartfoxserver/v2/entities/invitation/Invitation.hx
+++ b/com/smartfoxserver/v2/entities/invitation/Invitation.hx
@@ -21,7 +21,7 @@ interface Invitation
 	 * 
 	 *<p><b>NOTE</b>:setting the<em>id</em>property manually has no effect on the server and can disrupt the API functioning.</p>
 	 */
-	var id(get_id, set_id):Int;
+	var id(get, set):Int;
 	//function get id():Int
 	
 	/** @private */
@@ -30,26 +30,26 @@ interface Invitation
 	/** 
 	 * Returns the<em>User</em>object corresponding to the user who sent the invitation. 
 	 */
-	var inviter(get_inviter, null):User;
+	var inviter(get, null):User;
 	//function get inviter():User
 	
 	/** 
 	 * Returns the<em>User</em>object corresponding to the user who received the invitation. 
 	 */
-	var invitee(get_invitee, null):User;
+	var invitee(get, null):User;
 	//function get invitee():User
 	
 	/** 
 	 * Returns the number of seconds available to the invitee to reply to the invitation, after which the invitation expires.
 	 */
-	var secondsForAnswer(get_secondsForAnswer, null):Int;
+	var secondsForAnswer(get, null):Int;
 	//function get secondsForAnswer():Int
 	
 	/** 
 	 * Returns an instance of<em>SFSObject</em>containing a custom set of parameters.
 	 * It usually stores invitation details, like a message to the invitee and any other relevant data. 
 	 */
-	var params(get_params, null):ISFSObject;
+	var params(get, null):ISFSObject;
 	//function get params():ISFSObject
 }
 #end

--- a/com/smartfoxserver/v2/entities/invitation/SFSInvitation.hx
+++ b/com/smartfoxserver/v2/entities/invitation/SFSInvitation.hx
@@ -66,7 +66,7 @@ class SFSInvitation implements Invitation
 	}
 	
 	/** @inheritDoc */
-	public var id(get_id, set_id):Int;
+	public var id(get, set):Int;
  	private function get_id():Int
 	{
 	 	return _id;
@@ -79,28 +79,28 @@ class SFSInvitation implements Invitation
 	}
 	
 	/** @inheritDoc */
-	public var inviter(get_inviter, null):User;
+	public var inviter(get, null):User;
  	private function get_inviter():User
 	{
 		return _inviter;
 	}
 	
 	/** @inheritDoc */
-	public var invitee(get_invitee, null):User;
+	public var invitee(get, null):User;
  	private function get_invitee():User
 	{
 		return _invitee;
 	}
 	
 	/** @inheritDoc */
-	public var secondsForAnswer(get_secondsForAnswer, null):Int;
+	public var secondsForAnswer(get, null):Int;
  	private function get_secondsForAnswer():Int
 	{
 		return _secondsForAnswer;
 	}
 	
 	/** @inheritDoc */
-	public var params(get_params, null):ISFSObject;
+	public var params(get, null):ISFSObject;
  	private function get_params():ISFSObject
 	{
 		return _params;

--- a/com/smartfoxserver/v2/entities/managers/IBuddyManager.hx
+++ b/com/smartfoxserver/v2/entities/managers/IBuddyManager.hx
@@ -24,7 +24,7 @@ interface IBuddyManager
 	 * 
 	 * @see com.smartfoxserver.v2.requests.buddylist.InitBuddyListRequest InitBuddyListRequest
 	 */
-	var isInited(get_isInited, null):Bool;
+	var isInited(get, null):Bool;
 	//function get isInited():Bool
 	
 	/** @private */
@@ -94,7 +94,7 @@ interface IBuddyManager
 	 * 
 	 * @see		com.smartfoxserver.v2.entities.Buddy#isOnline Buddy.isOnline
 	 */
-	var offlineBuddies(get_offlineBuddies, null):Array<Buddy>;
+	var offlineBuddies(get, null):Array<Buddy>;
 	//function get offlineBuddies():Array
 	
 	/**
@@ -102,7 +102,7 @@ interface IBuddyManager
 	 * 
 	 * @see		com.smartfoxserver.v2.entities.Buddy#isOnline Buddy.isOnline
 	 */
-	var  onlineBuddies(get_onlineBuddies, null):Array<Buddy>;
+	var  onlineBuddies(get, null):Array<Buddy>;
 	
 	/**
 	 * Returns a list of<em>Buddy</em>objects representing all the buddies in the user's buddies list.
@@ -110,7 +110,7 @@ interface IBuddyManager
 	 * 
 	 * @see #isInited
 	 */
-	var buddyList(get_buddyList, null):Array<Buddy>;
+	var buddyList(get, null):Array<Buddy>;
 	//function get buddyList():Array
 	
 	/**
@@ -120,7 +120,7 @@ interface IBuddyManager
 	 * @see		com.smartfoxserver.v2.entities.Buddy#state Buddy.state
 	 */
 	//function get buddyStates():Array
-	var buddyStates(get_buddyStates, null):Array<String>;
+	var buddyStates(get, null):Array<String>;
 	
 	/**
 	 * Retrieves a Buddy Variable from its name.
@@ -140,7 +140,7 @@ interface IBuddyManager
 	 * @see		com.smartfoxserver.v2.entities.variables.BuddyVariable BuddyVariable
 	 * @see		#getMyVariable()
 	 */ 
-	var myVariables(get_myVariables, null):Array<BuddyVariable>;
+	var myVariables(get, null):Array<BuddyVariable>;
 	//function get myVariables():Array
 	
 	/**
@@ -153,7 +153,7 @@ interface IBuddyManager
 	 * @see		com.smartfoxserver.v2.entities.variables.ReservedBuddyVariables ReservedBuddyVariables
 	 * @see 	com.smartfoxserver.v2.requests.buddylist.GoOnlineRequest GoOnlineRequest
 	 */
-	var myOnlineState(get_myOnlineState, null):Bool;
+	var myOnlineState(get, null):Bool;
 	//function get myOnlineState():Bool
 	
 	/**
@@ -166,7 +166,7 @@ interface IBuddyManager
 	 * @see		com.smartfoxserver.v2.entities.variables.ReservedBuddyVariables ReservedBuddyVariables
 	 * @see 	com.smartfoxserver.v2.requests.buddylist.SetBuddyVariablesRequest SetBuddyVariablesRequest
 	 */
-	var myNickName(get_myNickName, null):String;
+	var myNickName(get, null):String;
 	//function get myNickName():String
 	
 	/**
@@ -179,7 +179,7 @@ interface IBuddyManager
 	 * @see		com.smartfoxserver.v2.entities.variables.ReservedBuddyVariables ReservedBuddyVariables
 	 * @see 	com.smartfoxserver.v2.requests.buddylist.SetBuddyVariablesRequest SetBuddyVariablesRequest
 	 */
-	var myState(get_myState, null):String;
+	var myState(get, null):String;
 	//function get myState():String
 	
 	/** @private */

--- a/com/smartfoxserver/v2/entities/managers/IRoomManager.hx
+++ b/com/smartfoxserver/v2/entities/managers/IRoomManager.hx
@@ -17,7 +17,7 @@ import com.smartfoxserver.v2.entities.User;
 interface IRoomManager
 {
 	/** @private */
-	var ownerZone(get_ownerZone, null):String;
+	var ownerZone(get, null):String;
 	//function get ownerZone():String
 	
 	/** @private */

--- a/com/smartfoxserver/v2/entities/managers/IRoomManager.hx
+++ b/com/smartfoxserver/v2/entities/managers/IRoomManager.hx
@@ -193,7 +193,7 @@ interface IRoomManager
 	function removeUser(user:User):Void;
 	
 	/** @private */
-	var  smartFox(get_smartFox, null):SmartFox;
+	var smartFox(get, null):SmartFox;
 	//function get smartFox():SmartFox
 }
 #end

--- a/com/smartfoxserver/v2/entities/managers/IUserManager.hx
+++ b/com/smartfoxserver/v2/entities/managers/IUserManager.hx
@@ -78,7 +78,7 @@ interface IUserManager
 	/**
 	 * Returns the total number of users in the local users list.
 	 */
-	var userCount(get_userCount, null):Int;
+	var userCount(get, null):Int;
 	//function get userCount():Int
 	
 	/**
@@ -89,6 +89,6 @@ interface IUserManager
 	function getUserList():Array<User>;
 	
 	/** @private */
-	var smartFox(get_smartFox, null):SmartFox;
+	var smartFox(get, null):SmartFox;
 	//function get smartFox():SmartFox
 }

--- a/com/smartfoxserver/v2/entities/managers/SFSBuddyManager.hx
+++ b/com/smartfoxserver/v2/entities/managers/SFSBuddyManager.hx
@@ -7,7 +7,7 @@ import com.smartfoxserver.v2.entities.variables.BuddyVariable;
 #if html5
 @:native('SFS2X.SFSBuddyManager')
 extern class SFSBuddyManager{
-	public var buddyList(get_buddyList,null):Array<Buddy>;
+	public var buddyList(get,null):Array<Buddy>;
 	inline function get_buddyList():Array<Buddy>
 	{
 		return getBuddyList();
@@ -82,7 +82,7 @@ class SFSBuddyManager implements IBuddyManager
 	}
 	
 	/** @inheritDoc */ 
-	public var isInited(get_isInited, null):Bool;
+	public var isInited(get, null):Bool;
  	private function get_isInited():Bool
 	{
 		return _inited;
@@ -168,7 +168,7 @@ class SFSBuddyManager implements IBuddyManager
 	}
 	
 	/** @inheritDoc */
-	public var offlineBuddies(get_offlineBuddies, null):Array<Buddy>;
+	public var offlineBuddies(get, null):Array<Buddy>;
  	private function get_offlineBuddies():Array<Buddy>
 	{
 		var buddies:Array<Buddy> = [];
@@ -183,7 +183,7 @@ class SFSBuddyManager implements IBuddyManager
 	}
 	
 	/** @inheritDoc */
-	public var onlineBuddies(get_onlineBuddies, null):Array<Buddy>;
+	public var onlineBuddies(get, null):Array<Buddy>;
 	
  	private function get_onlineBuddies():Array<Buddy>
 	{
@@ -199,7 +199,7 @@ class SFSBuddyManager implements IBuddyManager
 	}
 	
 	/** @inheritDoc */
-	public var buddyList(get_buddyList, null):Array<Buddy>;
+	public var buddyList(get, null):Array<Buddy>;
  	private function get_buddyList():Array<Buddy>
 	{
 		return Lambda.array(_buddiesByName);
@@ -212,14 +212,14 @@ class SFSBuddyManager implements IBuddyManager
 	}
 	
 	/** @inheritDoc */
-	public var myVariables(get_myVariables, null):Array<BuddyVariable>;
+	public var myVariables(get, null):Array<BuddyVariable>;
  	private function get_myVariables():Array<BuddyVariable>
 	{
 		return cast ArrayUtil.objToArray(_myVariables);	
 	}
 	
 	/** @inheritDoc */
-	public var myOnlineState(get_myOnlineState, null):Bool;
+	public var myOnlineState(get, null):Bool;
  	private function get_myOnlineState():Bool
 	{
 		// Manager not inited, we're offline
@@ -237,7 +237,7 @@ class SFSBuddyManager implements IBuddyManager
 	}
 	
 	/** @inheritDoc */
-	public var myNickName(get_myNickName, null):String;
+	public var myNickName(get, null):String;
  	private function get_myNickName():String
 	{
 		var nickNameVar:BuddyVariable = getMyVariable(ReservedBuddyVariables.BV_NICKNAME);
@@ -245,7 +245,7 @@ class SFSBuddyManager implements IBuddyManager
 	}
 	
 	/** @inheritDoc */
-	public var myState(get_myState, null):String;
+	public var myState(get, null):String;
  	private function get_myState():String
 	{
 		var stateVar:BuddyVariable = getMyVariable(ReservedBuddyVariables.BV_STATE);
@@ -253,7 +253,7 @@ class SFSBuddyManager implements IBuddyManager
 	}
 	
 	/** @inheritDoc */
-	public var buddyStates(get_buddyStates, null):Array<String>;
+	public var buddyStates(get, null):Array<String>;
  	private function get_buddyStates():Array<String>
 	{
 		return _buddyStates;

--- a/com/smartfoxserver/v2/entities/managers/SFSRoomManager.hx
+++ b/com/smartfoxserver/v2/entities/managers/SFSRoomManager.hx
@@ -60,7 +60,7 @@ class SFSRoomManager implements IRoomManager
 	}
 	
 	/** @private */
-	public var ownerZone(get_ownerZone, set_ownerZone):String;
+	public var ownerZone(get, set):String;
  	private function get_ownerZone():String
 	{
 		return _ownerZone;
@@ -73,7 +73,7 @@ class SFSRoomManager implements IRoomManager
 	}
 	
 	/** @private */
-	public var smartFox(get_smartFox, null):SmartFox;
+	public var smartFox(get, null):SmartFox;
  	private function get_smartFox():SmartFox
 	{
 		return _smartFox;

--- a/com/smartfoxserver/v2/entities/managers/SFSUserManager.hx
+++ b/com/smartfoxserver/v2/entities/managers/SFSUserManager.hx
@@ -114,14 +114,14 @@ class SFSUserManager implements IUserManager
 	}
 	
 	/** @inheritDoc */
-	public var userCount(get_userCount, null):Int;
+	public var userCount(get, null):Int;
  	private function get_userCount():Int
 	{
 		return Lambda.count(_usersById);
 	}
 	
 	/** @private */
-	public var smartFox(get_smartFox, null):SmartFox;
+	public var smartFox(get, null):SmartFox;
  	private function get_smartFox():SmartFox
 	{
 		return _smartFox;

--- a/com/smartfoxserver/v2/entities/match/LogicOperator.hx
+++ b/com/smartfoxserver/v2/entities/match/LogicOperator.hx
@@ -33,7 +33,7 @@ class LogicOperator
 	 * Returns the id of the current<em>LogicOperator</em>instance.
 	 * It can be the string "AND" or "OR".
 	 */
-	public var id(get_id, null):String;
+	public var id(get, null):String;
  	private function get_id():String
 	{
 		return _id;

--- a/com/smartfoxserver/v2/entities/variables/BuddyVariable.hx
+++ b/com/smartfoxserver/v2/entities/variables/BuddyVariable.hx
@@ -18,6 +18,6 @@ interface BuddyVariable extends UserVariable
 	 * Persistent Buddy Variables are also referred to as "offline variables" because they are available to all users
 	 * who have the owner in their Buddy Lists, whether that Buddy is online or not.</p>
 	 */
-	public var isOffline(get_isOffline, null):Bool;
+	public var isOffline(get, null):Bool;
 }
 #end

--- a/com/smartfoxserver/v2/entities/variables/SFSBuddyVariable.hx
+++ b/com/smartfoxserver/v2/entities/variables/SFSBuddyVariable.hx
@@ -95,21 +95,21 @@ class SFSBuddyVariable implements BuddyVariable
 	}
 	
 	/** @inheritDoc */
-	public var isOffline(get_isOffline, null):Bool;
+	public var isOffline(get, null):Bool;
  	private function get_isOffline():Bool
 	{
 		return _name.charAt(0) == "$";
 	}
 
 	/** @inheritDoc */
-	public var name(get_name, null):String;
+	public var name(get, null):String;
  	private function get_name():String
 	{
 		return _name;
 	}
 	
 	/** @inheritDoc */
-	public var type(get_type, null):String;
+	public var type(get, null):String;
  	private function get_type():String
 	{
 		return _type;

--- a/com/smartfoxserver/v2/entities/variables/SFSRoomVariable.hx
+++ b/com/smartfoxserver/v2/entities/variables/SFSRoomVariable.hx
@@ -74,14 +74,14 @@ class SFSRoomVariable extends SFSUserVariable implements RoomVariable
 	}
 	
 	/** @inheritDoc */
-	public var isPrivate(get_isPrivate, set_isPrivate):Bool;
+	public var isPrivate(get, set):Bool;
  	private function get_isPrivate():Bool
 	{
 		return _isPrivate;
 	}
 	
 	/** @inheritDoc */
-	public var isPersistent(get_isPersistent, set_isPersistent):Bool;
+	public var isPersistent(get, set):Bool;
  	private function get_isPersistent():Bool
 	{
 		return _isPersistent;

--- a/com/smartfoxserver/v2/entities/variables/SFSUserVariable.hx
+++ b/com/smartfoxserver/v2/entities/variables/SFSUserVariable.hx
@@ -116,14 +116,14 @@ class SFSUserVariable implements UserVariable
 	}
 	
 	/** @inheritDoc */
-	public var name(get_name, null):String;
+	public var name(get, null):String;
  	private function get_name():String
 	{
 		return _name;
 	}
 	
 	/** @inheritDoc */
-	public var type(get_type, null):String;
+	public var type(get, null):String;
  	private function get_type():String
 	{
 		return _type;

--- a/com/smartfoxserver/v2/exceptions/SFSError.hx
+++ b/com/smartfoxserver/v2/exceptions/SFSError.hx
@@ -12,7 +12,7 @@ class SFSError extends Error
 		_details=extra;
 	}
 	
-	public var details(get_details, null):String;
+	public var details(get, null):String;
  	private function get_details():String
 	{
 		return _details;

--- a/com/smartfoxserver/v2/exceptions/SFSValidationError.hx
+++ b/com/smartfoxserver/v2/exceptions/SFSValidationError.hx
@@ -12,7 +12,7 @@ class SFSValidationError extends Error
 		_errors = errors;
 	}
 	
-	public var errors(get_errors, null):Array<String>;
+	public var errors(get, null):Array<String>;
  	private function get_errors():Array<String>
 	{
 		return _errors;

--- a/com/smartfoxserver/v2/logging/Logger.hx
+++ b/com/smartfoxserver/v2/logging/Logger.hx
@@ -88,7 +88,7 @@ class Logger extends EventDispatcher
 	/**
 	 * Indicates whether or not the output of logged messages to the console window of Adobe Flash and Flex/Flash Builder is enabled.
 	 */
-	public var enableConsoleTrace(get_enableConsoleTrace, set_enableConsoleTrace):Bool;
+	public var enableConsoleTrace(get, set):Bool;
  	private function get_enableConsoleTrace():Bool
 	{
 		return _enableConsoleTrace;
@@ -108,7 +108,7 @@ class Logger extends EventDispatcher
 	 * @see 	#event:warn warn event
 	 * @see 	#event:error error event
 	 */
-	public var enableEventDispatching(get_enableEventDispatching, set_enableEventDispatching):Bool;
+	public var enableEventDispatching(get, set):Bool;
  	private function get_enableEventDispatching():Bool
 	{
 		return _enableEventDispatching;
@@ -127,7 +127,7 @@ class Logger extends EventDispatcher
 	 * 
 	 * @see		LogLevel
 	 */
-	public var loggingLevel(get_loggingLevel, set_loggingLevel):Int;
+	public var loggingLevel(get, set):Int;
  	private function get_loggingLevel():Int
 	{
 		return _loggingLevel;	

--- a/com/smartfoxserver/v2/protocol/IProtocolCodec.hx
+++ b/com/smartfoxserver/v2/protocol/IProtocolCodec.hx
@@ -11,5 +11,5 @@ interface IProtocolCodec
 	function onPacketRead(packet:Dynamic):Void;
 	function onPacketWrite(message:IMessage):Void;
 
-	public var ioHandler(get_ioHandler, set_ioHandler):IoHandler;
+	public var ioHandler(get, set):IoHandler;
 }

--- a/com/smartfoxserver/v2/requests/ExtensionRequest.hx
+++ b/com/smartfoxserver/v2/requests/ExtensionRequest.hx
@@ -101,7 +101,7 @@ class ExtensionRequest extends BaseRequest
 	}
 	
 	/** @private */
-	public var useUDP(get_useUDP, null):Bool;
+	public var useUDP(get, null):Bool;
  	private function get_useUDP():Bool
 	{
 		return _useUDP;

--- a/com/smartfoxserver/v2/requests/IRequest.hx
+++ b/com/smartfoxserver/v2/requests/IRequest.hx
@@ -11,7 +11,7 @@ interface IRequest
 	
 	public var targetController(get, set):Int;
 	
-	public var isEncrypted(get_isEncrypted, set_isEncrypted):Bool;
+	public var isEncrypted(get, set):Bool;
 	
 	function getMessage():IMessage;
 }

--- a/com/smartfoxserver/v2/requests/MessageRecipientMode.hx
+++ b/com/smartfoxserver/v2/requests/MessageRecipientMode.hx
@@ -80,7 +80,7 @@ class MessageRecipientMode
 	/**
 	 * Returns the selected recipient mode.
 	 */
-	public var mode(get_mode, null):Int;
+	public var mode(get, null):Int;
  	private function get_mode():Int
 	{
 		return _mode;
@@ -89,7 +89,7 @@ class MessageRecipientMode
 	/**
 	 * Returns the moderator/administrator message target, according to the selected recipient mode.
 	 */
-	public var target(get_target, null):Dynamic;
+	public var target(get, null):Dynamic;
  	private function get_target():Dynamic
 	{
 		return _target;

--- a/com/smartfoxserver/v2/requests/RoomEvents.hx
+++ b/com/smartfoxserver/v2/requests/RoomEvents.hx
@@ -44,7 +44,7 @@ class RoomEvents
 	 * 
 	 * @see		com.smartfoxserver.v2.SmartFox#event:userEnterRoom userEnterRoom event
 	 */
-	public var allowUserEnter(get_allowUserEnter, set_allowUserEnter):Bool;
+	public var allowUserEnter(get, set):Bool;
  	private function get_allowUserEnter():Bool 
 	{ 
 		return _allowUserEnter;
@@ -63,7 +63,7 @@ class RoomEvents
 	 * 
 	 * @see		com.smartfoxserver.v2.SmartFox#event:userExitRoom userExitRoom event
 	 */
-	public var allowUserExit(get_allowUserExit, set_allowUserExit):Bool;
+	public var allowUserExit(get, set):Bool;
  	private function get_allowUserExit():Bool 
 	{ 
 		return _allowUserExit;
@@ -82,7 +82,7 @@ class RoomEvents
 	 * 
 	 * @see		com.smartfoxserver.v2.SmartFox#event:userCountChange userCountChange event
 	 */
-	public var allowUserCountChange(get_allowUserCountChange, set_allowUserCountChange):Bool;
+	public var allowUserCountChange(get, set):Bool;
  	private function get_allowUserCountChange():Bool 
 	{ 
 		return _allowUserCountChange;
@@ -101,7 +101,7 @@ class RoomEvents
 	 * 
 	 * @see		com.smartfoxserver.v2.SmartFox#event:userVariablesUpdate userVariablesUpdate event
 	 */
-	public var allowUserVariablesUpdate(get_allowUserVariablesUpdate, set_allowUserVariablesUpdate):Bool;
+	public var allowUserVariablesUpdate(get, set):Bool;
  	private function get_allowUserVariablesUpdate():Bool 
 	{ 
 		return _allowUserVariablesUpdate;

--- a/com/smartfoxserver/v2/requests/RoomExtension.hx
+++ b/com/smartfoxserver/v2/requests/RoomExtension.hx
@@ -44,7 +44,7 @@ class RoomExtension
 	 * Returns the name of the Extension to be attached to the Room.
 	 * It's the name of the server-side folder containing the Extension classes inside the main<em>[sfs2x-install-folder]/SFS2X/extensions</em>folder.
 	 */
-	public var id(get_id, set_id):String;
+	public var id(get, set):String;
  	private function get_id():String
 	{
 		return _id;
@@ -58,7 +58,7 @@ class RoomExtension
 	/**
 	 * Returns the fully qualified name of the main class of the Extension.
 	 */
-	public var className(get_className, set_className):String;
+	public var className(get, set):String;
  	private function get_className():String
 	{
 		return _className;
@@ -74,7 +74,7 @@ class RoomExtension
 	 * 
 	 * @see		#id
 	 */
-	public var propertiesFile(get_propertiesFile, set_propertiesFile):String;
+	public var propertiesFile(get, set):String;
  	private function get_propertiesFile():String
 	{
 		return _propertiesFile;

--- a/com/smartfoxserver/v2/requests/RoomPermissions.hx
+++ b/com/smartfoxserver/v2/requests/RoomPermissions.hx
@@ -44,7 +44,7 @@ class RoomPermissions
 	 * 
 	 * @see		ChangeRoomNameRequest
 	 */
-	public var allowNameChange(get_allowNameChange, set_allowNameChange):Bool;
+	public var allowNameChange(get, set):Bool;
  	private function get_allowNameChange():Bool 
 	{ 
 		return _allowNameChange;
@@ -65,7 +65,7 @@ class RoomPermissions
 	 * 
 	 * @see		ChangeRoomPasswordStateRequest
 	 */
-	public var allowPasswordStateChange(get_allowPasswordStateChange, set_allowPasswordStateChange):Bool;
+	public var allowPasswordStateChange(get, set):Bool;
  	private function get_allowPasswordStateChange():Bool 
 	{ 
 		return _allowPasswordStateChange;
@@ -86,7 +86,7 @@ class RoomPermissions
 	 * 
 	 * @see		PublicMessageRequest
 	 */
-	public var allowPublicMessages(get_allowPublicMessages, set_allowPublicMessages):Bool;
+	public var allowPublicMessages(get, set):Bool;
  	private function get_allowPublicMessages():Bool 
 	{ 
 		return _allowPublicMessages;
@@ -108,7 +108,7 @@ class RoomPermissions
 	 * 
 	 * @see		ChangeRoomCapacityRequest
 	 */
-	public var allowResizing(get_allowResizing, set_allowResizing):Bool;
+	public var allowResizing(get, set):Bool;
  	private function get_allowResizing():Bool 
 	{ 
 		return _allowResizing;

--- a/com/smartfoxserver/v2/requests/RoomSettings.hx
+++ b/com/smartfoxserver/v2/requests/RoomSettings.hx
@@ -64,7 +64,7 @@ class RoomSettings
 	/**
 	 * Defines the name of the Room.
 	 */
-	public var name(get_name, set_name):String;
+	public var name(get, set):String;
  	private function get_name():String 
 	{ 
 		return _name;
@@ -82,7 +82,7 @@ class RoomSettings
 	 * 
 	 *<p>The default value is an empty string.</p>
 	 */
-	public var password(get_password, set_password):String;
+	public var password(get, set):String;
  	private function get_password():String 
 	{ 
 		return _password;
@@ -99,7 +99,7 @@ class RoomSettings
 	 * 
 	 * @default	false
 	 */
-	public var isGame(get_isGame, set_isGame):Bool;
+	public var isGame(get, set):Bool;
  	private function get_isGame():Bool 
 	{ 
 		return _isGame;
@@ -119,7 +119,7 @@ class RoomSettings
 	 * 
 	 * @see		#maxSpectators
 	 */
-	public var maxUsers(get_maxUsers, set_maxUsers):Int;
+	public var maxUsers(get, set):Int;
  	private function get_maxUsers():Int 
 	{ 
 		return _maxUsers;
@@ -136,7 +136,7 @@ class RoomSettings
 	 * 
 	 * @default	5
 	 */
-	public var maxVariables(get_maxVariables, set_maxVariables):Int;
+	public var maxVariables(get, set):Int;
  	private function get_maxVariables():Int 
 	{ 
 		return _maxVariables;
@@ -155,7 +155,7 @@ class RoomSettings
 	 * 
 	 * @see		#maxUsers
 	 */
-	public var maxSpectators(get_maxSpectators, set_maxSpectators):Int;
+	public var maxSpectators(get, set):Int;
  	private function get_maxSpectators():Int 
 	{ 
 		return _maxSpectators;
@@ -174,7 +174,7 @@ class RoomSettings
 	 * 
 	 * @see		com.smartfoxserver.v2.entities.variables.RoomVariable RoomVariable
 	 */
-	public var variables(get_variables, set_variables):Array<RoomVariable>;
+	public var variables(get, set):Array<RoomVariable>;
  	private function get_variables():Array<RoomVariable>
 	{ 
 		return _variables;
@@ -194,7 +194,7 @@ class RoomSettings
 	 * 
 	 * @default	null
 	 */ 
-	public var permissions(get_permissions, set_permissions):RoomPermissions;
+	public var permissions(get, set):RoomPermissions;
  	private function get_permissions():RoomPermissions 
 	{ 
 		return _permissions;
@@ -214,7 +214,7 @@ class RoomSettings
 	 * 
 	 * @default	null
 	 */ 
-	public var events(get_events, set_events):RoomEvents;
+	public var events(get, set):RoomEvents;
  	private function get_events():RoomEvents 
 	{ 
 		return _events;
@@ -229,7 +229,7 @@ class RoomSettings
 	/**
 	 * Defines the Extension that must be attached to the Room on the server-side, and its settings.
 	 */
-	public var extension(get_extension, set_extension):RoomExtension;
+	public var extension(get, set):RoomExtension;
  	private function get_extension():RoomExtension
 	{
 		return _extension;
@@ -249,7 +249,7 @@ class RoomSettings
 	 * 
 	 * @see com.smartfoxserver.v2.entities.Room#groupId
 	 */	
-	public var groupId(get_groupId, set_groupId):String;
+	public var groupId(get, set):String;
  	private function get_groupId():String
 	{
 		return _groupId;

--- a/com/smartfoxserver/v2/requests/mmo/MMORoomSettings.hx
+++ b/com/smartfoxserver/v2/requests/mmo/MMORoomSettings.hx
@@ -51,7 +51,7 @@ class MMORoomSettings extends RoomSettings
 	 * 
 	 * @example	A<code>Vec3D(120,120,60)</code>describes a range of 120 units in all four directions(top, bottom, left, right)and 60 units along the two Z-axis directions(backward, forward)with respect to the user position in a 3D coordinates system.
 	 */
-	public var defaultAOI(get_defaultAOI, set_defaultAOI):Vec3D;
+	public var defaultAOI(get, set):Vec3D;
  	private function get_defaultAOI():Vec3D
 	{
 		return _defaultAOI;
@@ -66,7 +66,7 @@ class MMORoomSettings extends RoomSettings
 	 * 
 	 *<p>This setting is optional but its usage is highly recommended.</p>
 	 */
-	public var mapLimits(get_mapLimits, set_mapLimits):MapLimits;
+	public var mapLimits(get, set):MapLimits;
  	private function get_mapLimits():MapLimits
 	{
 		return _mapLimits;
@@ -81,7 +81,7 @@ class MMORoomSettings extends RoomSettings
 	 * 
 	 * @default	50 seconds
 	 */
-	public var userMaxLimboSeconds(get_userMaxLimboSeconds, set_userMaxLimboSeconds):Int;
+	public var userMaxLimboSeconds(get, set):Int;
  	private function get_userMaxLimboSeconds():Int
 	{
 		return _userMaxLimboSeconds;
@@ -99,7 +99,7 @@ class MMORoomSettings extends RoomSettings
 	 * 
 	 * @see		com.smartfoxserver.v2.SmartFox#event:proximityListUpdate proximityListUpdate event
 	 */
-	public var proximityListUpdateMillis(get_proximityListUpdateMillis, set_proximityListUpdateMillis):Int;
+	public var proximityListUpdateMillis(get, set):Int;
  	private function get_proximityListUpdateMillis():Int
 	{
 		return _proximityListUpdateMillis;
@@ -117,7 +117,7 @@ class MMORoomSettings extends RoomSettings
 	 * @see		com.smartfoxserver.v2.entities.MMOItem#aoiEntryPoint MMOItem.aoiEntryPoint
 	 * @see		com.smartfoxserver.v2.SmartFox#event:proximityListUpdate proximityListUpdate event
 	 */
-	public var sendAOIEntryPoint(get_sendAOIEntryPoint, set_sendAOIEntryPoint):Bool;
+	public var sendAOIEntryPoint(get, set):Bool;
  	private function get_sendAOIEntryPoint():Bool
 	{
 		return _sendAOIEntryPoint;

--- a/com/smartfoxserver/v2/requests/mmo/MapLimits.hx
+++ b/com/smartfoxserver/v2/requests/mmo/MapLimits.hx
@@ -45,7 +45,7 @@ class MapLimits
 	/**
 	 * Returns the lower coordinates limit of the virtual environment along the X,Y,Z axes.
 	 */
-	public var lowerLimit(get_lowerLimit, null):Vec3D;
+	public var lowerLimit(get, null):Vec3D;
  	private function get_lowerLimit():Vec3D
 	{
 		return _lowerLimit;
@@ -54,7 +54,7 @@ class MapLimits
 	/**
 	 * Returns the higher coordinates limit of the virtual environment along the X,Y,Z axes.
 	 */
-	public var higherLimit(get_higherLimit, null):Vec3D;
+	public var higherLimit(get, null):Vec3D;
  	private function get_higherLimit():Vec3D
 	{
 		return _higherLimit;

--- a/com/smartfoxserver/v2/test/TestProtocolCodec.hx
+++ b/com/smartfoxserver/v2/test/TestProtocolCodec.hx
@@ -37,7 +37,7 @@ class TestProtocolCodec implements IProtocolCodec
 		trace("No write suppoerted")
 	}
 	
-	public var ioHandler(get_ioHandler, set_ioHandler):IoHandler;
+	public var ioHandler(get, set):IoHandler;
  	private function get_ioHandler():IoHandler
 	{
 		return null	

--- a/com/smartfoxserver/v2/util/LagMonitor.hx
+++ b/com/smartfoxserver/v2/util/LagMonitor.hx
@@ -60,7 +60,7 @@ class LagMonitor extends EventDispatcher
 		}
 	}
 	
-	public var isRunning(get_isRunning, null):Bool;
+	public var isRunning(get, null):Bool;
  	private function get_isRunning():Bool
 	{
 		return _thread.running;
@@ -81,7 +81,7 @@ class LagMonitor extends EventDispatcher
 		return averagePingTime;
 	}
 	
-	public var lastPingTime(get_lastPingTime, null):Float;
+	public var lastPingTime(get, null):Float;
  	private function get_lastPingTime():Float
 	{
 		if(_valueQueue.length>0)
@@ -90,7 +90,7 @@ class LagMonitor extends EventDispatcher
 			return 0;
 	}
 	
-	public var averagePingTime(get_averagePingTime, null):Float;
+	public var averagePingTime(get, null):Float;
  	private function get_averagePingTime():Float
 	{
 		if(_valueQueue.length==0)


### PR DESCRIPTION
This PR updates all the getters and setters to adopt the haxe 3 style and adds a `@:privateAccess metadata` in the constructor of `SmartFox`. This means haxe 2 is no longer supported (if it was).