### PR TITLE
Fix lag monitoring values

### DIFF
--- a/com/smartfoxserver/v2/util/LagMonitor.hx
+++ b/com/smartfoxserver/v2/util/LagMonitor.hx
@@ -69,7 +69,7 @@ class LagMonitor extends EventDispatcher
 	public function onPingPong():Float
 	{
 		// Calculate lag
-		var lagValue:Float= haxe.Timer.stamp() - _lastReqTime;
+		var lagValue:Float= 1000. * (haxe.Timer.stamp() - _lastReqTime);
 		
 		// Remove older value
 		if(_valueQueue.length>=_queueSize)


### PR DESCRIPTION
This PR changes the lag values from seconds to milliseconds as specified in the doc: http://docs2x.smartfoxserver.com/api-docs/jsdoc/client/SFSEvent.html#.PING_PONG