### PR TITLE
Support for Haxe 4.1

### DIFF
--- a/com/smartfoxserver/v2/entities/data/SFSArray.hx
+++ b/com/smartfoxserver/v2/entities/data/SFSArray.hx
@@ -47,11 +47,7 @@ extern class SFSArray
 		return getWrappedItem(index);
 	}
 	function getWrappedItem(index:Int):Dynamic;
-	@:overload(function (value:Dynamic, typeId:Int):Void{})
-	inline function add(data:SFSDataWrapper):Void
-	{
-		add(data.data,data.type);
-	}
+	function add(value:Dynamic, typeId:Int):Void;
 	
 
 	function addBool(value:Bool):Void;

--- a/com/smartfoxserver/v2/entities/data/SFSObject.hx
+++ b/com/smartfoxserver/v2/entities/data/SFSObject.hx
@@ -51,11 +51,7 @@ extern class SFSObject
 	function getUtfStringArray(key:String):Array<String>;
 	function getWrappedItem(key:String):SFSDataWrapper;
 	function isNull(key:String):Bool;
-	@:overload(function (key:String, value:Dynamic, typeId:Int):Void{})
-	inline function put(key:String,dataWrapper:SFSDataWrapper):Void
-	{
-		put(key,dataWrapper.data,dataWrapper.type);
-	}
+	function put(key:String, value:Dynamic, typeId:Int):Void;
 	function putBool(key:String, value:Bool):Void;
 	function putBoolArray(key:String, array:Array<Bool>):Void;
 	function putByte(key:String, value:Int):Void;

--- a/com/smartfoxserver/v2/protocol/serialization/DefaultSFSDataSerializer.hx
+++ b/com/smartfoxserver/v2/protocol/serialization/DefaultSFSDataSerializer.hx
@@ -158,8 +158,14 @@ class DefaultSFSDataSerializer implements ISFSDataSerializer
 		 		var decodedObject:SFSDataWrapper = decodeObject(buffer);
 		 		
 		 		// Store decoded object and keep going
-		 		if(decodedObject !=null)
-		 			sfsObject.put(key, decodedObject);
+				if(decodedObject !=null)
+				{
+					#if html5
+					sfsObject.put(key, decodedObject.data, decodedObject.type);
+					#else
+					sfsObject.put(key, decodedObject);
+					#end
+				}
 		 		else
 		 			throw new SFSCodecError("Could not decode value for SFSObject with key:" + key);
 		 	}	
@@ -216,8 +222,14 @@ class DefaultSFSDataSerializer implements ISFSDataSerializer
 		 		var decodedObject:SFSDataWrapper = decodeObject(buffer);
 
 		 		// Store decoded object and keep going
-		 		if(decodedObject !=null)
-		 			sfsArray.add(decodedObject);
+				if(decodedObject !=null)
+				{
+					#if html5
+					sfsArray.add(decodedObject.data, decodedObject.type);
+					#else
+					sfsArray.add(decodedObject);
+					#end
+				}
 		 		else
 		 			throw new SFSCodecError("Could not decode SFSArray item at index:" + i);
 		 	}	
@@ -916,7 +928,12 @@ class DefaultSFSDataSerializer implements ISFSDataSerializer
 			fieldDescriptor.putUtfString(FIELD_NAME_KEY, fieldName);
 			
 			// store field value
-			fieldDescriptor.put(FIELD_VALUE_KEY, wrapASField(fieldValue));
+			var data = wrapASField(fieldValue);
+			#if html5
+			fieldDescriptor.put(FIELD_VALUE_KEY, data.data, data.type);
+			#else
+			fieldDescriptor.put(FIELD_VALUE_KEY, data);
+			#end
 			
 			// add to the list of fields
 			fieldList.addSFSObject(fieldDescriptor);
@@ -970,7 +987,14 @@ class DefaultSFSDataSerializer implements ISFSDataSerializer
 		var sfsArray:ISFSArray = SFSArray.newInstance();
 		
 		for(j in 0...arr.length)
-			sfsArray.add(wrapASField(arr[j]));
+		{
+			var data = wrapASField(arr[j]);
+			#if html5
+			sfsArray.add(data.data, data.type);
+			#else
+			sfsArray.add(data);
+			#end
+		}
 			
 		return sfsArray;
 	}
@@ -980,7 +1004,14 @@ class DefaultSFSDataSerializer implements ISFSDataSerializer
 		var sfsObj:ISFSObject = SFSObject.newInstance();
 		
 		for(key in Reflect.fields(dict))
-			sfsObj.put(key, wrapASField(Reflect.field(dict,key)));
+		{
+			var data = wrapASField(Reflect.field(dict,key));
+			#if html5
+			sfsObj.put(key, data.data, data.type);
+			#else
+			sfsObj.put(key, data);
+			#end
+		}
 			
 		return sfsObj;
 	}


### PR DESCRIPTION
This PR removes all `@:overload` + `inline` as it is now forbidden: https://github.com/HaxeFoundation/haxe/commit/5a28ae0c23a13851d7f76a8d0eed5492f75621c4