### PR TITLE
Use Colyseus WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ openfl: 8.9.5
     
 haxe-crypto: 0.0.7    
   
-haxe-ws: 1.0.5  
+colyseus-websocket: 1.0.10  
     
 ----------------------------------    
     

--- a/haxelib.json
+++ b/haxelib.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/barisyild/smartfox-haxe-client",
     "dependencies": {
 		"haxe-crypto":"",
-		"haxe-ws":"",
+		"colyseus-websocket":"",
         "openfl":""
     }
 }

--- a/hxmlApp/build.hxml
+++ b/hxmlApp/build.hxml
@@ -1,7 +1,7 @@
 -cp src
 -dce full
 -lib haxe-crypto
--lib haxe-ws
+-lib colyseus-websocket
 #-lib hxssl
 #-lua bin/lua.lua
 #-php bin/php


### PR DESCRIPTION
[`haxe-ws` is deprecated](https://github.com/soywiz/haxe-ws/issues/24) and this PR replaces it with [`colyseus-websocket`](https://github.com/colyseus/colyseus-websocket-hx), which is still maintained and more stable.