### PR TITLE
Fix compile for 9.2.0 older versions

### DIFF
--- a/com/smartfoxserver/v2/exceptions/SFSError.hx
+++ b/com/smartfoxserver/v2/exceptions/SFSError.hx
@@ -14,7 +14,7 @@ class SFSError extends Error
 	
 	#if (openfl <= "9.1.0")
 	public var details(get, null):String;
- 	private override function get_details():String
+ 	private function get_details():String
 	{
 		return _details;
 	}


### PR DESCRIPTION
This pull request solves the compile problem of versions below 9.2.0.
